### PR TITLE
Update ng-ckeditor.src.js

### DIFF
--- a/ng-ckeditor.src.js
+++ b/ng-ckeditor.src.js
@@ -29,7 +29,7 @@ app.run(['$q', '$timeout', function($q, $timeout) {
     $timeout(checkLoaded, 100);
 }])
 
-app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {
+app.directive('$rootScope', 'ckeditor', ['$timeout', '$q', function ($rootScope, $timeout, $q) {
     'use strict';
 
     return {
@@ -107,6 +107,8 @@ app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {
                 instance.on('key',          setModelData); // for source view
 
                 instance.on('instanceReady', function() {
+                    $rootScope.$broadcast( "ckeditor.ready" );
+
                     scope.$apply(function() {
                         onUpdateModelData(true);
                     });


### PR DESCRIPTION
Exposes the editor being ready to broader application environment, allowing things like:
## HTML

```
<div ng-controller="EditingController">
    <div ng-cloak ng-hide="isReady" class="highlight">
    Initialising ...
    </div>
    <div ng-cloak ng-show="isReady">
        The Textarea with ckeditor directive etc here
    </div>
</div>
```
## APPLICATION

```
var editingController = [ "$scope", function( scope ) {
    scope.editorOptions = {
        config etc here
    };

    scope.$on( "ckeditor.ready", function( event ) {
        scope.isReady = true;
    });
}];

AdvancedEditor.controller("EditingController", editingController);
```

Allows us to hide everything until all rendered - useful when ckeditor needs to auto resize to fit placement space and when we add extra controls (external to the editor) that depend upon it etc ...
