### PR TITLE
Fix bug in source mode where key one char behind.

### DIFF
--- a/ng-ckeditor.src.js
+++ b/ng-ckeditor.src.js
@@ -81,11 +81,11 @@ app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {
                     );
                 });
                 var setModelData = function(setPristine) {
-                    var data = instance.getData();
-                    if (data == EMPTY_HTML) {
-                        data = null;
-                    }
                     $timeout(function () { // for key up event
+                        var data = instance.getData();
+                        if (data == EMPTY_HTML) {
+                            data = null;
+                        }
                         ngModel.$setViewValue(data);
                         (setPristine === true && form) && form.$setPristine();
                     }, 0);


### PR DESCRIPTION
In source mode, the data retrieved via getData was always one
character behind the last key press. By moving the call to
getData inside the $timeout, we get the current data value
before updating the model's view value.
