### PR TITLE
Emit ckeditor.ready event instead of broadcasting and send instance

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -107,7 +107,7 @@ app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {
                 //instance.on('key',          setModelData); // for source view
 
                 instance.on('instanceReady', function() {
-                    scope.$broadcast("ckeditor.ready");
+                    scope.$emit("ckeditor.ready", instance);
                     scope.$apply(function() {
                         onUpdateModelData(true);
                     });


### PR DESCRIPTION
It seems to me (and certainly is so in my case) that it's more useful to `$emit` the ckeditor.ready event rather than `$broadcast` it so parent scopes hear about it instead of child scopes. For example, it allows me to use `ng-if` and still hear the event.

Also, it's useful to send a reference to the instance with the event.
