### PR TITLE
Extend options with

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -29,7 +29,7 @@ app.run(['$q', '$timeout', function($q, $timeout) {
     $timeout(checkLoaded, 100);
 }])
 
-app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {
+app.directive('ckeditor', ['$timeout', '$q', '$parse', function ($timeout, $q, $parse) {
     'use strict';
 
     return {
@@ -70,7 +70,7 @@ app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {
                     height: '400px',
                     width: '100%'
                 };
-                options = angular.extend(options, scope[attrs.ckeditor]);
+                options = angular.extend(options, $parse(attrs.ckeditor)(scope));
 
                 var instance = (isTextarea) ? CKEDITOR.replace(element[0], options) : CKEDITOR.inline(element[0], options),
                     configLoaderDef = $q.defer();


### PR DESCRIPTION
By extending options through $parse you don't limit yourself to the current scope.
For example, if you use ckeditor in multiple places on your app you can can add the ckeditor's options to the rootScope and use always the same ones without having to rewrite the same code for every controller and directive.
