### PR TITLE
checkLoaded causes an stack-exceeded-error

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -22,11 +22,11 @@ app.run(['$q', '$timeout', function($q, $timeout) {
             loaded = true;
             $defer.resolve();
         } else {
-            checkLoaded();
+            $timeout(checkLoaded, 100);
         }
     }
     CKEDITOR.on('loaded', checkLoaded);
-    $timeout(checkLoaded, 100);
+    checkLoaded();
 }])
 
 app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {


### PR DESCRIPTION
Having checkLoaded in call itself recursivly causes an stack-exceeded-error:

RangeError: Maximum call stack size exceeded
    at checkLoaded ([...]/bower/ng-ckeditor/ng-ckeditor.js?22:20:25)
    at checkLoaded ([...]/bower/ng-ckeditor/ng-ckeditor.js?22:25:2)
    at checkLoaded ([...]/bower/ng-ckeditor/ng-ckeditor.js?22:25:2)
...
