### PR TITLE
Update ng-ckeditor.js

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -78,9 +78,9 @@ app.directive('ckeditor', ['$timeout', '$q', function ($timeout, $q) {
                     configLoaderDef = $q.defer();
 
                 element.bind('$destroy', function () {
-                    instance.destroy(
-                        false //If the instance is replacing a DOM element, this parameter indicates whether or not to update the element with the instance contents.
-                    );
+                    if (instance && CKEDITOR.instances[instance.name]) {
+                      CKEDITOR.instances[instance.name].destroy();
+                    }
                 });
                 var setModelData = function(setPristine) {
                     var data = instance.getData();


### PR DESCRIPTION
Destroy doesn't work on angularjs version > 1.3 joined with jquery-ui.
I suggest this workaround.