### PR TITLE
Set form to pristine after render

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -134,7 +134,7 @@
                     ngModel.$render = function () {
                         data.push(ngModel.$viewValue);
                         if (isReady) {
-                            onUpdateModelData();
+                            onUpdateModelData(true);
                         }
                     };
                 };


### PR DESCRIPTION
Hi,
We are using your directive to integrate CKEditor and Angular in our project. However, after updating the data from the server (for example when navigating around the web site), we see that the form containing the editor is set to dirty, even though the user has not changed the text.

My change is to set the form to pristine when ngModel.$render is called, so the form is dirty because the model is updated with new infomration from the server.