### PR TITLE
Ensure instance.document exists

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -125,7 +125,11 @@
                             onUpdateModelData(true);
                         });
 
-                        instance.document.on('keyup', setModelData);
+                        if (instance.document) {
+                            instance.document.on('keyup', setModelData);
+                        } else {
+                            instance.on('keyup', setModelData);
+                        }
                     });
                     instance.on('customConfigLoaded', function () {
                         configLoaderDef.resolve();


### PR DESCRIPTION
If ckeditor is started in source view mode (.e.g 'startupMode: 'source'" in $scope.editorOptions), calling instance.document.on('keyup') will
throw an exception because instance.document is undefined. In this case, it's better to set a listener on instance itself.