### PR TITLE
fix: latest model data is always set to instance

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -44,6 +44,7 @@
                 var EMPTY_HTML = '<p></p>',
                     isTextarea = element[0].tagName.toLowerCase() === 'textarea',
                     data = [],
+                    dataDirty = false,
                     isReady = false;
 
                 if (!isTextarea) {
@@ -108,9 +109,14 @@
 
                         var item = data.pop() || EMPTY_HTML;
                         isReady = false;
+                    	dataDirty = false;
                         instance.setData(item, function () {
                             setModelData(setPristine);
-                            isReady = true;
+                            if(dataDirty) {
+                            	onUpdateModelData();
+                            } else {
+                            	isReady = true;
+                            }
                         });
                     };
 
@@ -135,6 +141,8 @@
                         data.push(ngModel.$viewValue);
                         if (isReady) {
                             onUpdateModelData();
+                        } else {
+                            dataDirty = true;
                         }
                     };
                 };


### PR DESCRIPTION
If the model data is updated during instance.setData, then the latest model data will be missed.
See https://github.com/esvit/ng-ckeditor/issues/41.