### PR TITLE
external plugins

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -37,7 +37,10 @@
         return {
             restrict: 'AC',
             require: ['ngModel', '^?form'],
-            scope: false,
+            scope: {
+                ckeditor: '=',
+                ckPlugins: '=?'
+            },
             link: function (scope, element, attrs, ctrls) {
                 var ngModel = ctrls[0];
                 var form = ctrls[1] || null;
@@ -78,6 +81,15 @@
                         width: '100%'
                     };
                     options = angular.extend(options, scope[attrs.ckeditor]);
+
+                    // Manage the plugins on ckEditor
+                    if ((!angular.isUndefined(scope.ckPlugins)) && (scope.ckPlugins.length > 0)) {
+
+                        scope.ckPlugins.map(function (plugin) {
+                            var filename = plugin.filename || 'plugin.js';
+                            CKEDITOR.plugins.addExternal(plugin.name, plugin.path, filename);
+                        });
+                    }
 
                     var instance = (isTextarea) ? CKEDITOR.replace(element[0], options) : CKEDITOR.inline(element[0], options),
                         configLoaderDef = $q.defer();


### PR DESCRIPTION
I used a ckeditor in cdn and I use some plugin which are in my local workspace. However ckeditor permit me to add my personals plugins located in other folder. 

---

I created this pull request to add a new property angular which permit to manage personal plugins.
this option permit to add plugin with CKEDITOR.plugins.addExternal method before replacement textarea.
By default the filename is plugins.js if the value is not defined on the configuration. like this example

i.e 
View
```html
<textarea cols="30" rows="40"
    data-ng-model="test.description"
    name="description"
    ckeditor="test.editorOptions"  ck-plugins="test.plugins">
</textarea>
```
controller
```javascript
this.plugins = [
        {
            name: 'autosave',
            path: '/ckeditor/plugins/autosave/',
            filename: 'otherName.js'
        }, {
            name: 'lineutils',
            path: '/ckeditor/plugins/lineutils/'
        }, {
            name: 'wordcount',
            path: '/ckeditor/plugins/wordcount/'
        }
]

this.editorOptions = {
    language: 'fr',
    uiColor: '#ffffff'
}
```
