### PR TITLE
Fixed #71 - model update after image upload

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -114,7 +114,7 @@
                         });
                     };
 
-                    //instance.on('pasteState',   setModelData);
+                    instance.on('pasteState',   setModelData);
                     instance.on('change', setModelData);
                     instance.on('blur', setModelData);
                     //instance.on('key',          setModelData); // for source view


### PR DESCRIPTION
Re-enabling the event handler for 'pasteState' fixes the problem where the angular model is not updated after copy/drop uploading an image via imageupload plugin.