### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Code licensed under New BSD License.
 bower install ng-ckeditor
 ```
 
-##Usage
+## Usage
 ```html
 <textarea ckeditor="editorOptions" ng-model="modelName"></textarea>
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
